### PR TITLE
remove unneeded dependency

### DIFF
--- a/alica_viewer/package.xml
+++ b/alica_viewer/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>roscpp</depend>
-  <depend>qt_build</depend>
   <depend>libqt4-dev</depend>
 
   <depend>agent_id</depend>


### PR DESCRIPTION
The qt_build dependency is unnecessary and this package is not available on melodic which breaks rosdep. Tested removing this package does not affect alica_viewer build and run in on kinetic and melodic.